### PR TITLE
feat: routing patterns

### DIFF
--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -1,6 +1,7 @@
 import SignIn from "@/components/SignIn";
 import { buttonVariants } from "@/components/ui/Button";
 import { cn } from "@/lib/utils";
+import { ChevronLeft } from "lucide-react";
 import Link from "next/link";
 import { FC } from "react";
 
@@ -15,6 +16,7 @@ const page: FC = () => {
             "self-start -mt-20"
           )}
         >
+          <ChevronLeft className="mr-2 h-4 w-4" />
           Home
         </Link>
 

--- a/src/app/@authModal/(.)sign-in/page.tsx
+++ b/src/app/@authModal/(.)sign-in/page.tsx
@@ -1,0 +1,23 @@
+import CloseModal from "@/components/CloseModal";
+import SignIn from "@/components/SignIn";
+import { FC } from "react";
+
+interface pageProps {}
+
+const page: FC<pageProps> = ({}) => {
+  return (
+    <div className="fixed inset-0 bg-zinc-900/20 z-10">
+      <div className="container flex items-center h-full max-w-lg mx-auto">
+        <div className="relative bg-white w-full h-fit py-20 px-2 rounded-lg">
+          <div className="absolute top-4 right-4">
+            <CloseModal />
+          </div>
+
+          <SignIn />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default page;

--- a/src/app/@authModal/default.tsx
+++ b/src/app/@authModal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,8 +13,10 @@ const inter = Inter({ subsets: ["latin"] });
 
 export default function RootLayout({
   children,
+  authModal
 }: {
   children: React.ReactNode;
+  authModal: React.ReactNode;
 }) {
   return (
     <html
@@ -25,7 +27,10 @@ export default function RootLayout({
       )}
     >
       <body className="min-h-screen pt-12 bg-slate-50 antialiased">
+        {/* @ts-expect-error server component */}
         <Navbar />
+
+        {authModal}
 
         <div className="container max-7xl mx-auto h-full pt-12">{children}</div>
 

--- a/src/app/legal/user-agreement/page.tsx
+++ b/src/app/legal/user-agreement/page.tsx
@@ -1,0 +1,56 @@
+import { FC } from "react";
+
+const page: FC = () => {
+  return (
+    <div className="h-full mx-auto">
+      <h1 className="bg-[#F1ECE6] h-20 w-full text-5xl text-center">User Agreement</h1>
+
+      <main>
+        <section>
+          <em>Effective on November 21, 2023</em>
+
+          <p>
+            Our mission is to connect the world's professionals to allow them to
+            be more productive and successful. Our services are designed to
+            promote economic opportunity for our members by enabling you and
+            millions of other professionals to meet, exchange ideas, learn, and
+            find opportunities or employees, work, and make decisions in a
+            network of trusted relationship.
+          </p>
+
+          <h2>Table of Contents:</h2>
+
+          <ol>
+            <li>Introduction</li>
+            <li>Obligations</li>
+            <li>Rights and Limits</li>
+            <li>Disclaimer and Limit of Liability</li>
+            <li>Termination</li>
+            <li>Governing Law and Dispute Resolution</li>
+            <li>General Terms</li>
+            <li>Breadit "Dos and Don´ts"</li>
+            <li>Complaints Regarding Content</li>
+            <li>How To Contact Us</li>
+          </ol>
+        </section>
+
+        <section>
+          <h2>Introduction</h2>
+          <h3>1.1 Contract</h3>
+
+          <div>
+            {/* lamp icon */}
+            <p>
+              When you use our Services you agree to all of these terms. Your
+              use of our Services is also subject to our Cookie Policy and our
+              Privacy Policy, which covers how we collect, use, share, and store
+              your personal information.
+            </p>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default page;

--- a/src/components/CloseModal.tsx
+++ b/src/components/CloseModal.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { X } from "lucide-react";
+import { Button } from "./ui/Button";
+import { useRouter } from "next/navigation";
+
+const CloseModal = () => {
+  const router = useRouter();
+
+  return (
+    <Button
+      variant="subtle"
+      className="h-6 w-6 p-0 rounded-md"
+      onClick={() => router.back()}
+      aria-label="close modal"
+    >
+      <X className="h-4 w-4" />
+    </Button>
+  );
+};
+
+export default CloseModal;


### PR DESCRIPTION
### Advanced Routing patterns

created a default folder for intercepting routes and do something. 
`src/app/@authModal/(.)sign-in/page.tsx`

The user clicks on the button to go to sign-in page but instead of taking him to sign-in page we intercept the route and show a modal so he can authenticate. We let the user experience better and gain performance.

We also have a default value for the routing pattern which we return `null`
`src/app/@authModal/default.tsx`

We needed to extend it to our **layout.tsx**

```
export default function RootLayout({
  children,
  **authModal**
}: {
  children: React.ReactNode;
  **authModal: React.ReactNode;**
}) {
  return (
    <html

```

### Components

- [x] CloseModal - use client component


### New page Structure 
`src/app/legal/`

. New page: 

`src/app/legal/user-agreement/page.tsx`